### PR TITLE
Add block main_content_wrapper

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -234,7 +234,7 @@
                         <div id="sidebar-resizer-handler" class="resizer-handler resizer-handler-left"></div>
                     </aside>
                 </div>
-
+                {% block main_content_wrapper %}
                 <section class="main-content">
                     {% set has_search = ea.crud is not null and ea.crud.isSearchEnabled %}
                     <aside class="content-top {{ has_search ? 'ea-search-enabled' : 'ea-search-disabled' }}">
@@ -376,6 +376,7 @@
                         <div id="content-resizer-handler" class="resizer-handler resizer-handler-right"></div>
                     </div>
                 </section>
+                {% endblock main_content_wrapper %}
             {% endblock wrapper %}
         </div>
     {% endblock wrapper_wrapper %}


### PR DESCRIPTION
main-content is the only major section of layout.html.twig that is missing a wrapping block. This adds it in so we can add content before or after it.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
